### PR TITLE
Updated packages to latest. Replaced 'angular-cli'

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,21 +30,21 @@
   },
   "devDependencies": {
     "@angular/compiler-cli": "^2.3.1",
+    "@angular/cli": "^1.0.0-beta.31",
     "@types/hammerjs": "^2.0.34",
-    "@types/jasmine": "2.5.38",
-    "@types/node": "^6.0.42",
-    "angular-cli": "1.0.0-beta.24",
+    "@types/jasmine": "2.5.42",
+    "@types/node": "^7.0.5",
     "codelyzer": "~2.0.0-beta.1",
     "jasmine-core": "2.5.2",
-    "jasmine-spec-reporter": "2.5.0",
-    "karma": "1.2.0",
+    "jasmine-spec-reporter": "3.2.0",
+    "karma": "1.4.1",
     "karma-chrome-launcher": "^2.0.0",
     "karma-cli": "^1.0.1",
     "karma-jasmine": "^1.0.2",
-    "karma-remap-istanbul": "^0.2.1",
-    "protractor": "~4.0.13",
-    "ts-node": "1.2.1",
+    "karma-remap-istanbul": "^0.6.0",
+    "protractor": "~5.1.1",
+    "ts-node": "2.1.0",
     "tslint": "^4.0.2",
-    "typescript": "~2.0.3"
+    "typescript": "~2.1.6"
   }
 }


### PR DESCRIPTION
Replaced 'angular-cli' package (deprecated) with '@angular/cli'. 

Was getting "Cannot find module '@angular/compiler-cli'" on clean install.